### PR TITLE
Added  Pencil 2 Interaction Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ drawView.undo()
 drawView.redo()
 ``` 
     
+
+## Apple Pencil Integration
+This is only supported for iOS 12.1 and above versions
+
+### Apple Pencil 2 Double Tap action
+#### Enable/ Disable pencil interaction
+Apple Pencil interaction is enabled by default, but you can set `drawView.isPencilInteractive` to change that setting.
+#### Pencil Events
+When double tapping the pencil, SwiftyDraw will check the user preferences set in the system. If the preference is set to switch to eraser, SwiftyDraw will switch between normal and erasing mode; if set to last used tool, SwiftyDraw will switch between current and previous brush.
+
 ## Delegate
 
 SwiftyDraw has delegate functions to notify you when a user is interacting with a SwiftDrawView. To access these delegate methods, simply make your View Controller conform to the `SwiftyDrawViewDelegate` protocol:

--- a/SwiftyDrawExample/SwiftyDrawExample.xcodeproj/project.pbxproj
+++ b/SwiftyDrawExample/SwiftyDrawExample.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.linus-geffarth.SwiftyDrawExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -320,7 +320,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.linus-geffarth.SwiftyDrawExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/SwiftyDrawExample/SwiftyDrawExample/Base.lproj/Main.storyboard
+++ b/SwiftyDrawExample/SwiftyDrawExample/Base.lproj/Main.storyboard
@@ -262,6 +262,7 @@
                     </view>
                     <connections>
                         <outlet property="drawView" destination="Jqo-l8-EIq" id="1LA-Mx-mEv"/>
+                        <outlet property="eraserButton" destination="p8A-ij-1ZV" id="kce-EN-Pni"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/SwiftyDrawExample/SwiftyDrawExample/ViewController.swift
+++ b/SwiftyDrawExample/SwiftyDrawExample/ViewController.swift
@@ -12,6 +12,7 @@ extension ViewController: SwiftyDrawViewDelegate {
 class ViewController: UIViewController {
     
     @IBOutlet var drawView: SwiftyDrawView!
+    @IBOutlet var eraserButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,7 +39,17 @@ class ViewController: UIViewController {
     }
     
     @IBAction func activateEraser() {
-        drawView.brush.blendMode = .clear
+        if drawView.brush.blendMode == .normal{
+            //Switch to clear
+            drawView.brush.blendMode = .clear
+            eraserButton.tintColor = .red
+            eraserButton.setTitle("deactivate eraser", for: .normal)
+        } else {
+            //Switch to normal
+            drawView.brush.blendMode = .normal
+            eraserButton.tintColor = self.view.tintColor
+            eraserButton.setTitle("activate eraser", for: .normal)
+        }
     }
     
     @IBAction func clearCanvas() {


### PR DESCRIPTION
For issue #20 

- **Added support to receive  Pencil 2 double tap events.**
According to user's preference, a double tap can either enable/disable eraser, or switch between current brush and the previous one.

- **Slight Adjustment to example project so eraser mode can be deactivated.**