### PR TITLE
straight line

### DIFF
--- a/Source/Brush.swift
+++ b/Source/Brush.swift
@@ -36,33 +36,33 @@ public class Brush {
         guard #available(iOS 9.1, *), touch.type == .pencil else { return originalWidth }
         return (originalWidth*(1-adjustedWidthFactor/10*2)) + (adjustedWidthFactor/touch.altitudeAngle)
     }
-
+    
     public func adjustWidth(for touch: UITouch) {
         width = adjustedWidth(for: touch)
     }
-
+    
     // MARK: - Static brushes
     
     public static var `default`: Brush {
         return Brush(color: .black, width: 3, opacity: 1)
     }
-
+    
     public static var thin: Brush {
         return Brush(color: .black, width: 2, opacity: 1)
     }
-
+    
     public static var medium: Brush {
         return Brush(color: .black, width: 7, opacity: 1)
     }
-
+    
     public static var thick: Brush {
         return Brush(color: .black, width: 10, opacity: 1)
     }
-
+    
     public static var marker: Brush {
         return Brush(color: #colorLiteral(red: 0.920953393, green: 0.447560966, blue: 0.4741248488, alpha: 1), width: 10, opacity: 0.3)
     }
-
+    
     public static var eraser: Brush {
         return Brush(adjustedWidthFactor: 5, blendMode: .clear)
     }
@@ -77,8 +77,8 @@ extension Brush: Equatable, Comparable, CustomStringConvertible {
     public static func ==(lhs: Brush, rhs: Brush) -> Bool {
         return (
             lhs.color == rhs.color &&
-            lhs.originalWidth == rhs.originalWidth &&
-            lhs.opacity == rhs.opacity
+                lhs.originalWidth == rhs.originalWidth &&
+                lhs.opacity == rhs.opacity
         )
     }
     

--- a/Source/SwiftyDraw.swift
+++ b/Source/SwiftyDraw.swift
@@ -67,6 +67,10 @@ open class SwiftyDrawView: UIView {
     }
     /// Sets whether touch gestures should be registered as drawing strokes on the current canvas
     public var isEnabled = true
+    
+    /// sets whether the line drawn should be straight
+    public var isStraight = false
+    
     /// Sets whether responde to Apple Pencil interactions, like the Double tap for Apple Pencil 2 to switch tools.
     public var isPencilInteractive : Bool = true {
         didSet{
@@ -95,9 +99,10 @@ open class SwiftyDrawView: UIView {
     @available(iOS 9.1, *)
     public lazy var allowedTouchTypes: [TouchType] = [.finger, .pencil]
     
-    public var lines: [Line] = []
-    public var drawingHistory: [Line] = []
-    private var currentPoint: CGPoint = .zero
+    public  var lines: [Line] = []
+    public  var drawingHistory: [Line] = []
+    public  var firstPoint: CGPoint = .zero      // created this variable
+    public  var currentPoint: CGPoint = .zero     // made public
     private var previousPoint: CGPoint = .zero
     private var previousPreviousPoint: CGPoint = .zero
     
@@ -167,6 +172,7 @@ open class SwiftyDrawView: UIView {
         delegate?.swiftyDraw(didBeginDrawingIn: self, using: touch)
         
         setTouchPoints(touch, view: self)
+        firstPoint = touch.location(in: self)       // for drawing straight lines
         let newLine = Line(path: CGMutablePath(),
                            brush: Brush(color: brush.color, width: brush.width, opacity: brush.opacity, blendMode: brush.blendMode))
         newLine.path.addPath(createNewPath())
@@ -183,9 +189,20 @@ open class SwiftyDrawView: UIView {
         delegate?.swiftyDraw(isDrawingIn: self, using: touch)
         
         updateTouchPoints(for: touch, in: self)
-        let newPath = createNewPath()
-        if let currentPath = lines.last {
-            currentPath.path.addPath(newPath)
+        
+        if isStraight {
+            lines.removeLast()
+            
+            let newLine = Line(path: CGMutablePath(),
+                               brush: Brush(color: brush.color, width: brush.width, opacity: brush.opacity, blendMode: brush.blendMode))
+            newLine.path.addPath(createNewStraightPath())
+            lines.append(newLine)
+            drawingHistory = lines
+        } else {
+            let newPath = createNewPath()
+            if let currentPath = lines.last {
+                currentPath.path.addPath(newPath)
+            }
         }
     }
     
@@ -238,7 +255,7 @@ open class SwiftyDrawView: UIView {
         setNeedsDisplay()
     }
     
-/********************************** Private Functions **********************************/
+    /********************************** Private Functions **********************************/
     
     private func setTouchPoints(_ touch: UITouch,view: UIView) {
         previousPoint = touch.previousLocation(in: view)
@@ -259,6 +276,14 @@ open class SwiftyDrawView: UIView {
         return newPath
     }
     
+    private func createNewStraightPath() -> CGMutablePath {
+        let pt1 : CGPoint = firstPoint
+        let pt2 : CGPoint = currentPoint
+        let subPath = createStraightSubPath(pt1, mid2: pt2)
+        let newPath = addSubPathToPath(subPath)
+        return newPath
+    }
+    
     private func calculateMidPoint(_ p1 : CGPoint, p2 : CGPoint) -> CGPoint {
         return CGPoint(x: (p1.x + p2.x) * 0.5, y: (p1.y + p2.y) * 0.5);
     }
@@ -273,6 +298,13 @@ open class SwiftyDrawView: UIView {
         let subpath : CGMutablePath = CGMutablePath()
         subpath.move(to: CGPoint(x: mid1.x, y: mid1.y))
         subpath.addQuadCurve(to: CGPoint(x: mid2.x, y: mid2.y), control: CGPoint(x: previousPoint.x, y: previousPoint.y))
+        return subpath
+    }
+    
+    private func createStraightSubPath(_ mid1: CGPoint, mid2: CGPoint) -> CGMutablePath {
+        let subpath : CGMutablePath = CGMutablePath()
+        subpath.move(to: mid1)
+        subpath.addLine(to: mid2)
         return subpath
     }
     


### PR DESCRIPTION
I've had a go at implement a straight line for https://github.com/Awalz/SwiftyDraw/issues/4

I've made a public variable [`isStraight`](https://github.com/dcooley/SwiftyDraw/blob/master/Source/SwiftyDraw.swift#L72) 

```swift
/// sets whether the line drawn should be straight
public var isStraight = false
```

which, when set to `true` creates a straight line between the first touch point and the current point

```swift
lines.removeLast()
            
let newLine = Line(path: CGMutablePath(),
    brush: Brush(color: brush.color, width: brush.width, opacity: brush.opacity, blendMode: brush.blendMode))
newLine.path.addPath(createNewStraightPath())
lines.append(newLine)
drawingHistory = lines
```

Using the methods

```swift
    private func createNewStraightPath() -> CGMutablePath {
        let pt1 : CGPoint = firstPoint
        let pt2 : CGPoint = currentPoint
        let subPath = createStraightSubPath(pt1, mid2: pt2)
        let newPath = addSubPathToPath(subPath)
        return newPath
    }

    private func createStraightSubPath(_ mid1: CGPoint, mid2: CGPoint) -> CGMutablePath {
        let subpath : CGMutablePath = CGMutablePath()
        subpath.move(to: mid1)
        subpath.addLine(to: mid2)
        return subpath
    }

```


