### PR TITLE
Added Codable conformity to DrawItem

### DIFF
--- a/Source/SwiftyDraw.swift
+++ b/Source/SwiftyDraw.swift
@@ -401,3 +401,33 @@ extension SwiftyDrawView : UIPencilInteractionDelegate{
         }
     }
 }
+
+extension SwiftyDrawView.DrawItem: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let pathData = try container.decode(Data.self, forKey: .path)
+        let uiBezierPath = try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(pathData) as! UIBezierPath
+        path = uiBezierPath.cgPath as! CGMutablePath
+    
+        brush = try container.decode(Brush.self, forKey: .brush)
+        isFillPath = try container.decode(Bool.self, forKey: .isFillPath)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        let uiBezierPath = UIBezierPath(cgPath: path)
+        let pathData = NSKeyedArchiver.archivedData(withRootObject: uiBezierPath)
+        try container.encode(pathData, forKey: .path)
+        
+        try container.encode(brush, forKey: .brush)
+        try container.encode(isFillPath, forKey: .isFillPath)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case brush
+        case path
+        case isFillPath
+    }
+}


### PR DESCRIPTION
Issue #21 
I've added Codable conformity to DrawItem.

`encode(to encoder:)` first converts CGMutablePath to UIBezierPath, which conforms to NSSecureCoding. 
It then converts UIBezierPath to Data using NSKeyedArchiver. 
Further Information: https://www.hackingwithswift.com/example-code/language/how-to-store-nscoding-data-using-codable

DrawItem could be encoded/decoded by the code below.
```swift
let encodedData = JSONEncoder().encode(drawItem)
let decodedDrawItem = JSONDecoder().decode(SwiftyDrawView.DrawItem, from: encodedData)
```