### PR TITLE
Fixed mismatch of label and blendMode on Sample app

### DIFF
--- a/SwiftyDrawExample/SwiftyDrawExample/ViewController.swift
+++ b/SwiftyDrawExample/SwiftyDrawExample/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
     @IBAction func selectedColor(_ button: UIButton) {
         guard let color = button.backgroundColor else { return }
         drawView.brush.color = Color(color)
-        drawView.brush.blendMode = .normal
+        deactivateErasor()
     }
     
     @IBAction func undo() {
@@ -55,20 +55,16 @@ class ViewController: UIViewController {
     @IBAction func toggleEraser() {
         if drawView.brush.blendMode == .normal {
             //Switch to clear
-            drawView.brush.blendMode = .clear
-            eraserButton.tintColor = .red
-            eraserButton.setTitle("deactivate eraser", for: .normal)
+            activateErasor()
         } else {
             //Switch to normal
-            drawView.brush.blendMode = .normal
-            eraserButton.tintColor = self.view.tintColor
-            eraserButton.setTitle("activate eraser", for: .normal)
+            deactivateErasor()
         }
     }
     
     @IBAction func clearCanvas() {
         drawView.clear()
-        drawView.brush.blendMode = .normal
+        deactivateErasor()
     }
     
     @IBAction func setDrawMode() {
@@ -109,7 +105,19 @@ class ViewController: UIViewController {
     
     @IBAction func changedOpacity(_ slider: UISlider) {
         drawView.brush.opacity = CGFloat(slider.value)
+        deactivateErasor()
+    }
+    
+    func activateErasor() {
+        drawView.brush.blendMode = .clear
+        eraserButton.tintColor = .red
+        eraserButton.setTitle("deactivate eraser", for: .normal)
+    }
+    
+    func deactivateErasor() {
         drawView.brush.blendMode = .normal
+        eraserButton.tintColor = self.view.tintColor
+        eraserButton.setTitle("activate eraser", for: .normal)
     }
 }
 


### PR DESCRIPTION
I fixed a bug on the Sample app.

brush.blendMode is changed to .normal on selectedColor() and clearCanvas(), but the text and color of eraserButton were not updated on these events.

activate/deactivateErasor() activates/deactivates Eraser, and also updates the button to match the current state.
I modified the code to call these functions on selectedColor(), clearCanvas() and toggleEraser().